### PR TITLE
New concept of ioc source id

### DIFF
--- a/ejb/src/main/java/biz/karms/sinkit/ejb/ArchiveServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/ArchiveServiceEJB.java
@@ -2,6 +2,7 @@ package biz.karms.sinkit.ejb;
 
 import biz.karms.sinkit.exception.ArchiveException;
 import biz.karms.sinkit.ioc.IoCRecord;
+
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.core.Index;
@@ -32,7 +33,8 @@ public class ArchiveServiceEJB {
     public static final String ELASTIC_IOC_INDEX = "iocs";
     public static final String ELASTIC_IOC_TYPE = "intelmq";
 
-    public IoCRecord findActiveIoCRecordByIp(String ip, String type, String feed) throws ArchiveException {
+    public IoCRecord findActiveIoCRecordBySourceId(
+            String sourceId, String classificationType, String feedName) throws ArchiveException {
 
         //log.info("searching elastic [ ip : " + ip + ", type : " + type + ", feed : " + feed + "]");
 
@@ -41,7 +43,9 @@ public class ArchiveServiceEJB {
                 "       \"filtered\" : {\n"+
                 "           \"query\" : {\n" +
                 "               \"query_string\" : {\n" +
-                "                   \"query\": \"active : true AND source.ip : " + ip + " AND classification.type: " + type + " AND feed.name : " + feed +"\"\n" +
+                "                   \"query\": \"active : true AND source.id.value : \\\"" + sourceId + "\\\" AND " +
+                                                "classification.type: \\\"" + classificationType + "\\\" AND " +
+                                                "feed.name : \\\"" + feedName +"\\\"\"\n" +
                 "               }\n" +
                 "           }\n" +
                 "       }\n" +
@@ -51,24 +55,43 @@ public class ArchiveServiceEJB {
         return this.searchArchiveForSingleHit(query);
     }
 
-    public IoCRecord findActiveIoCRecordByFQDN(String fqdn, String type, String feed) throws ArchiveException {
-
-        //log.info("searching elastic [ fqdn : " + fqdn + ", type : " + type + ", feed : " + feed + "]");
-
-        String query = "{\n" +
-                "   \"query\" : {\n" +
-                "       \"filtered\" : {\n"+
-                "           \"query\" : {\n" +
-                "               \"query_string\" : {\n" +
-                "                   \"query\": \"active : true AND source.fqdn : " + fqdn + " AND classification.type: " + type + " AND feed.name : " + feed +"\"\n" +
-                "               }\n" +
-                "           }\n" +
-                "       }\n" +
-                "   }\n" +
-                "}\n";
-
-       return this.searchArchiveForSingleHit(query);
-    }
+//    public IoCRecord findActiveIoCRecordByIp(String ip, String type, String feed) throws ArchiveException {
+//
+//        //log.info("searching elastic [ ip : " + ip + ", type : " + type + ", feed : " + feed + "]");
+//
+//        String query = "{\n" +
+//                "   \"query\" : {\n" +
+//                "       \"filtered\" : {\n"+
+//                "           \"query\" : {\n" +
+//                "               \"query_string\" : {\n" +
+//                "                   \"query\": \"active : true AND source.ip : \\\"" + ip + "\\\" AND classification.type: \\\"" + type + "\\\" AND feed.name : \\\"" + feed +"\\\"\"\n" +
+//                "               }\n" +
+//                "           }\n" +
+//                "       }\n" +
+//                "   }\n" +
+//                "}\n";
+//
+//        return this.searchArchiveForSingleHit(query);
+//    }
+//
+//    public IoCRecord findActiveIoCRecordByFQDN(String fqdn, String type, String feed) throws ArchiveException {
+//
+//        //log.info("searching elastic [ fqdn : " + fqdn + ", type : " + type + ", feed : " + feed + "]");
+//
+//        String query = "{\n" +
+//                "   \"query\" : {\n" +
+//                "       \"filtered\" : {\n"+
+//                "           \"query\" : {\n" +
+//                "               \"query_string\" : {\n" +
+//                "                   \"query\": \"active : true AND source.fqdn : \\\"" + fqdn + "\\\" AND classification.type: \\\"" + type + "\\\" AND feed.name : \\\"" + feed +"\\\"\"\n" +
+//                "               }\n" +
+//                "           }\n" +
+//                "       }\n" +
+//                "   }\n" +
+//                "}\n";
+//
+//       return this.searchArchiveForSingleHit(query);
+//    }
 
     public List<IoCRecord> findIoCsForDeactivation(int hours) throws ArchiveException {
 

--- a/ejb/src/main/java/biz/karms/sinkit/exception/IoCSourceIdException.java
+++ b/ejb/src/main/java/biz/karms/sinkit/exception/IoCSourceIdException.java
@@ -1,0 +1,27 @@
+package biz.karms.sinkit.exception;
+
+/**
+ * Created by tkozel on 10.7.15.
+ */
+public class IoCSourceIdException extends Exception {
+
+    public IoCSourceIdException() {
+        super();
+    }
+
+    public IoCSourceIdException(String message) {
+        super(message);
+    }
+
+    public IoCSourceIdException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public IoCSourceIdException(Throwable cause) {
+        super(cause);
+    }
+
+    protected IoCSourceIdException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSource.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSource.java
@@ -16,6 +16,9 @@ public class IoCSource implements Serializable {
     private static final long serialVersionUID = 2184815523047755695L;
 
     @Field
+    private IoCSourceId id;
+
+    @Field
     private String url;
 
     @Field
@@ -42,6 +45,14 @@ public class IoCSource implements Serializable {
     @Field
     @SerializedName("bgp_prefix")
     private String bgpPrefix;
+
+    public IoCSourceId getId() {
+        return id;
+    }
+
+    public void setId(IoCSourceId id) {
+        this.id = id;
+    }
 
     public String getUrl() {
         return url;
@@ -110,7 +121,8 @@ public class IoCSource implements Serializable {
     @Override
     public String toString() {
         return "IoCSource{" +
-                "url='" + url + '\'' +
+                "id=" + id +
+                ", url='" + url + '\'' +
                 ", ip='" + ip + '\'' +
                 ", fqdn='" + fqdn + '\'' +
                 ", reverseDomainName='" + reverseDomainName + '\'' +

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSourceId.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSourceId.java
@@ -1,0 +1,45 @@
+package biz.karms.sinkit.ioc;
+
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+import java.io.Serializable;
+
+/**
+ * Created by tkozel on 10.7.15.
+ */
+@Indexed
+public class IoCSourceId implements Serializable {
+
+    private static final long serialVersionUID = 2184815523040755395L;
+
+    @Field
+    private String value;
+
+    @Field
+    private IoCSourceIdType type;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public IoCSourceIdType getType() {
+        return type;
+    }
+
+    public void setType(IoCSourceIdType type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return "IoCSourceId{" +
+                "value='" + value + '\'' +
+                ", type=" + type +
+                '}';
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSourceIdType.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSourceIdType.java
@@ -1,0 +1,18 @@
+package biz.karms.sinkit.ioc;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Created by tkozel on 10.7.15.
+ */
+public enum IoCSourceIdType {
+
+    @SerializedName("url")
+    URL,
+
+    @SerializedName("ip")
+    IP,
+
+    @SerializedName("fqdn")
+    FQDN
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/util/IoCSourceIdBuilder.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/util/IoCSourceIdBuilder.java
@@ -1,0 +1,31 @@
+package biz.karms.sinkit.ioc.util;
+
+import biz.karms.sinkit.exception.IoCSourceIdException;
+import biz.karms.sinkit.ioc.IoCRecord;
+import biz.karms.sinkit.ioc.IoCSourceId;
+import biz.karms.sinkit.ioc.IoCSourceIdType;
+
+/**
+ * Created by tkozel on 10.7.15.
+ */
+public class IoCSourceIdBuilder {
+
+    public static IoCSourceId build(IoCRecord ioc) throws IoCSourceIdException {
+
+        IoCSourceId sid = new IoCSourceId();
+        if (ioc.getSource().getUrl() != null ) {
+            sid.setValue(ioc.getSource().getUrl());
+            sid.setType(IoCSourceIdType.URL);
+        } else if (ioc.getSource().getFQDN() != null) {
+            sid.setValue(ioc.getSource().getFQDN());
+            sid.setType(IoCSourceIdType.FQDN);
+        } else if (ioc.getSource().getIp() != null) {
+            sid.setValue(ioc.getSource().getIp());
+            sid.setType(IoCSourceIdType.IP);
+        } else {
+            throw new IoCSourceIdException("Can't build IoCSourceId: Unknown type of IoC source.");
+        }
+
+        return sid;
+    }
+}

--- a/rest/src/main/java/biz/karms/sinkit/rest/SinkitService.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/SinkitService.java
@@ -115,7 +115,9 @@ public class SinkitService implements Serializable {
             if (ioc.getFeed() == null || ioc.getFeed().getName() == null) {
                 throw new Exception("IoC record doesn't have mandatory field 'feed.name'");
             }
-            if (ioc.getSource() == null || (ioc.getSource().getFQDN() == null && ioc.getSource().getIp() == null)) {
+            if (ioc.getSource() == null || (
+                    ioc.getSource().getFQDN() == null && ioc.getSource().getIp() == null && ioc.getSource().getUrl() == null
+                    )) {
                 throw new Exception("IoC can't have both IP and Domain set as null");
             }
             if (ioc.getClassification() == null || ioc.getClassification().getType() == null) {


### PR DESCRIPTION
New concept of IoC source id:
- id (or key) of blacklisted entity is now contained in iocRecord.getSource().getId().getValue(), this field contains URL or IP or FQDN that identifies the source of given IoC record.
- cache doesn't have to take care of what property of ioc source (iocRecord.getSource().getUrl, getIp(), getFQDN, etc) has to be used as the key (this decision is made durin processing of IoC recieved from IntelMQ)
- the type of id is stored in iocRecord.getSource().getId().getType() (enum IoCSourceIdType) is used to make decision whether the ioc record should be put into cache or not 
- iocs of IoCSourceIdType.IP or IoCSourceIdType.FQND are only put into cache