### PR TITLE
Http Response codes support

### DIFF
--- a/ejb/src/main/java/biz/karms/sinkit/exception/IoCSourceIdException.java
+++ b/ejb/src/main/java/biz/karms/sinkit/exception/IoCSourceIdException.java
@@ -3,7 +3,7 @@ package biz.karms.sinkit.exception;
 /**
  * Created by tkozel on 10.7.15.
  */
-public class IoCSourceIdException extends Exception {
+public class IoCSourceIdException extends IoCValidationException {
 
     public IoCSourceIdException() {
         super();

--- a/ejb/src/main/java/biz/karms/sinkit/exception/IoCValidationException.java
+++ b/ejb/src/main/java/biz/karms/sinkit/exception/IoCValidationException.java
@@ -1,0 +1,26 @@
+package biz.karms.sinkit.exception;
+
+/**
+ * Created by tkozel on 24.7.15.
+ */
+public class IoCValidationException extends Exception {
+    public IoCValidationException() {
+        super();
+    }
+
+    public IoCValidationException(String message) {
+        super(message);
+    }
+
+    public IoCValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public IoCValidationException(Throwable cause) {
+        super(cause);
+    }
+
+    protected IoCValidationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/rest/src/main/java/biz/karms/sinkit/rest/SinkitService.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/SinkitService.java
@@ -1,6 +1,9 @@
 package biz.karms.sinkit.rest;
 
 import biz.karms.sinkit.ejb.*;
+import biz.karms.sinkit.exception.ArchiveException;
+import biz.karms.sinkit.exception.IoCSourceIdException;
+import biz.karms.sinkit.exception.IoCValidationException;
 import biz.karms.sinkit.ioc.IoCRecord;
 import com.google.gson.GsonBuilder;
 
@@ -108,35 +111,10 @@ public class SinkitService implements Serializable {
         return new GsonBuilder().create().toJson(message);
     }
 
-    String processIoCRecord(String jsonIoCRecord) {
+    String processIoCRecord(String jsonIoCRecord) throws IoCValidationException, ArchiveException {
 
-        String response;
-        try {
-            IoCRecord ioc = new GsonBuilder().setDateFormat(IoCRecord.DATE_FORMAT).create().fromJson(jsonIoCRecord, IoCRecord.class);
-
-            if (ioc.getFeed() == null || ioc.getFeed().getName() == null) {
-                throw new Exception("IoC record doesn't have mandatory field 'feed.name'");
-            }
-            if (ioc.getSource() == null || (
-                    ioc.getSource().getFQDN() == null && ioc.getSource().getIp() == null && ioc.getSource().getUrl() == null
-            )) {
-                throw new Exception("IoC can't have both IP and Domain set as null");
-            }
-            if (ioc.getClassification() == null || ioc.getClassification().getType() == null) {
-                throw new Exception("IoC record doesn't have mandatory field 'classification.type'");
-            }
-            if (ioc.getTime() == null || ioc.getTime().getObservation() == null) {
-                throw new Exception("IoC record doesn't have mandatory field 'time.observation'");
-            }
-
-            ioc = coreService.processIoCRecord(ioc);
-
-            response = new GsonBuilder().setDateFormat(IoCRecord.DATE_FORMAT).create().toJson(ioc);
-        } catch (Exception e) {
-            e.printStackTrace();
-            log.log(Level.SEVERE, "IoC: " + jsonIoCRecord);
-            response = new GsonBuilder().setDateFormat(IoCRecord.DATE_FORMAT).create().toJson(e.getMessage());
-        }
-        return response;
+        IoCRecord ioc = new GsonBuilder().setDateFormat(IoCRecord.DATE_FORMAT).create().fromJson(jsonIoCRecord, IoCRecord.class);
+        ioc = coreService.processIoCRecord(ioc);
+        return new GsonBuilder().setDateFormat(IoCRecord.DATE_FORMAT).create().toJson(ioc);
     }
 }


### PR DESCRIPTION
Support for http response codes. Implemented only in REST method putIoCRecord yet. 
- if authorization fails the code 401 (UNAUTHORIZED) is returned (not logged)
- if received IoC record doesn't fulfil necessary conditions (including JSON syntax errors) the code 400 (BAD_REQUEST) is returned (not logged)
- if processing fails from whatever reason the code 500 (INTERNAL_SERVER_ERROR) is returned (exception stacktrace is logged)
- otherwise everything is ok the code 200 is returned

Logical validation of received IoC record is moved into CoreServiceEJB. Rest module serves only as envelope for core logic. The only duty is to serialize/deserialize IoC to/from Json (and authentication and all the stuff around http of course)