### PR TITLE
Cache rebuilding feature

### DIFF
--- a/ejb/src/main/java/biz/karms/sinkit/ejb/CacheBuilderEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/CacheBuilderEJB.java
@@ -1,0 +1,79 @@
+package biz.karms.sinkit.ejb;
+
+import biz.karms.sinkit.ioc.IoCRecord;
+import javax.ejb.*;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+/**
+ * Created by tkozel on 26.7.15.
+ */
+@Singleton
+public class CacheBuilderEJB {
+
+    private AtomicBoolean cacheRebuilding = new AtomicBoolean(false);
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private ArchiveServiceEJB archiveService;
+
+    @Lock(LockType.READ)
+    public boolean isCacheRebuildRunning() {
+        return cacheRebuilding.get();
+    }
+
+    @Asynchronous
+    @Lock(LockType.READ)
+    public Future<Integer> runCacheRebuilding() throws ConcurrentAccessException {
+
+        if (!cacheRebuilding.compareAndSet(false, true)) {
+            log.info("Cache rebuilding still in process -> skipping");
+            throw new ConcurrentAccessException("Cache rebuilding already in progress...");
+        }
+
+        try {
+            return new AsyncResult<>(this.rebuildCache());
+        } finally {
+            cacheRebuilding.set(false);
+        }
+    }
+
+    private int rebuildCache() {
+
+        log.info("Rebuilding Cache started");
+
+        // TODO clearCache HERE
+
+        int recordsCount = 0;
+        int from = 0;
+        int size = 1000;
+
+        List<IoCRecord> iocs;
+
+        try {
+            do {
+                iocs = archiveService.getActiveIoCs(from, size);
+                for (IoCRecord ioc : iocs) {
+                    //TODO cacheService.addToCache(ioc);
+                }
+                recordsCount += iocs.size();
+                from += size;
+                log.info("Cache rebuilding: processing batch of " + iocs.size() + " iocs");
+
+            } while (iocs.size() >= size);
+
+        } catch (Exception ex)  {
+            log.severe("Cache rebuilding failed: " + ex.getMessage());
+            ex.printStackTrace();
+        }
+
+        log.info("Cache rebuilding: rebuilding finished -  " + recordsCount + " iocs processed.");
+
+        return  recordsCount;
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/CoreServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/CoreServiceEJB.java
@@ -5,22 +5,16 @@ import biz.karms.sinkit.eventlog.EventLogAction;
 import biz.karms.sinkit.eventlog.EventLogRecord;
 import biz.karms.sinkit.eventlog.EventReason;
 import biz.karms.sinkit.exception.ArchiveException;
-import biz.karms.sinkit.exception.IoCSourceIdException;
 import biz.karms.sinkit.exception.IoCValidationException;
 import biz.karms.sinkit.ioc.IoCRecord;
 import biz.karms.sinkit.ioc.IoCSeen;
 import biz.karms.sinkit.ioc.IoCSourceId;
 import biz.karms.sinkit.ioc.IoCSourceIdType;
 import biz.karms.sinkit.ioc.util.IoCSourceIdBuilder;
-
-import javax.ejb.Schedule;
-import javax.ejb.Schedules;
-import javax.ejb.Singleton;
-import javax.ejb.Stateless;
+import javax.ejb.*;
 import javax.inject.Inject;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -39,6 +33,9 @@ public class CoreServiceEJB {
 
     @Inject
     private ServiceEJB cacheService;
+
+    @Inject
+    private CacheBuilderEJB cacheBuilder;
 
     public synchronized IoCRecord processIoCRecord(IoCRecord receivedIoc)
             throws ArchiveException, IoCValidationException {
@@ -152,6 +149,16 @@ public class CoreServiceEJB {
         return ioc;
     }
 
+    public synchronized boolean runCacheRebuilding() {
+
+        if (cacheBuilder.isCacheRebuildRunning()) {
+            log.info("Cache rebuilding still in process -> skipping");
+            return false;
+        }
+
+        cacheBuilder.runCacheRebuilding();
+        return true;
+    }
 
     private Date addWindow(Date date) {
         Calendar c = Calendar.getInstance();

--- a/rest/src/main/java/biz/karms/sinkit/rest/SinkitREST.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/SinkitREST.java
@@ -130,6 +130,19 @@ public class SinkitREST {
         }
     }
 
+    @POST
+    @Path("/rebuildCache/")
+    @Produces({"application/json;charset=UTF-8"})
+    public Response rebuildCache(@HeaderParam(AUTH_HEADER_PARAM) String token) {
+
+        if (!stupidAuthenticator.isAuthenticated(token)) {
+            return Response.status(Response.Status.UNAUTHORIZED).entity(AUTH_FAIL).build();
+        }
+
+        String response = sinkitService.runCacheRebuilding();
+        return Response.status(Response.Status.OK).entity(response).build();
+    }
+
     /**
      * Rules
      */

--- a/rest/src/main/java/biz/karms/sinkit/rest/SinkitService.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/SinkitService.java
@@ -117,4 +117,16 @@ public class SinkitService implements Serializable {
         ioc = coreService.processIoCRecord(ioc);
         return new GsonBuilder().setDateFormat(IoCRecord.DATE_FORMAT).create().toJson(ioc);
     }
+
+    String runCacheRebuilding() {
+
+        String response;
+        if (coreService.runCacheRebuilding()) {
+            response = "Cache rebuilding started";
+        } else {
+            response = "Cache rebuilding already started";
+        }
+        return new GsonBuilder().create().toJson(response);
+
+    }
 }


### PR DESCRIPTION
CoreService is prepared for cache rebuilding. When cache flushing is ready on side of infinispan, than the feature will be completed.

Cache rebuilding can be started via REST method rebuildCache. 

```curl  -w "@curl-format.txt" -i -H " -H "X-sinkit-token: ${SINKIT_ACCESS_TOKEN}" -X POST http://localhost:8080/sinkit/rest/rebuildCache```

Rebuilding runs asynchronously and cannot be started again until it's finished.

ArchiveService is singleton now.