### PR TITLE
virus-total

### DIFF
--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -122,6 +122,13 @@
             <artifactId>jest</artifactId>
             <version>${io.searchbox.jest.version}</version>
         </dependency>
+
+        <!-- VirusTotal client-->
+        <dependency>
+            <groupId>com.kanishka.api</groupId>
+            <artifactId>VirustotalPublicV2.0</artifactId>
+            <version>1.1.GA-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.kanishka.api</groupId>
             <artifactId>VirustotalPublicV2.0</artifactId>
-            <version>1.1.GA-SNAPSHOT</version>
+            <version>${com.kanishka.api.VirustotalPublicV2.0.version}</version>
         </dependency>
     </dependencies>
 

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/Resources.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/Resources.java
@@ -1,5 +1,9 @@
 package biz.karms.sinkit.ejb;
 
+import biz.karms.sinkit.ejb.elastic.JestClientProvider;
+import biz.karms.sinkit.ejb.virustotal.VirusTotalClientProvider;
+import com.kanishka.virustotal.exception.APIKeyNotFoundException;
+import com.kanishka.virustotalv2.VirustotalPublicV2;
 import io.searchbox.client.JestClient;
 import org.infinispan.manager.DefaultCacheManager;
 
@@ -19,9 +23,6 @@ public class Resources {
     @Inject
     MyCacheManagerProvider cacheManagerProvider;
 
-    @Inject
-    JestClientProvider jestClientProvider;
-
     @Produces
     @Default
     Logger getLogger(InjectionPoint ip) {
@@ -34,11 +35,4 @@ public class Resources {
     DefaultCacheManager getDefaultCacheManager() {
         return cacheManagerProvider.getCacheManager();
     }
-
-    @Produces
-    @Default
-    JestClient getJestClient() {
-        return jestClientProvider.getJestClient();
-    }
-
 }

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticResources.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticResources.java
@@ -1,0 +1,24 @@
+package biz.karms.sinkit.ejb.elastic;
+
+import io.searchbox.client.JestClient;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+/**
+ * Created by tkozel on 4.8.15.
+ */
+@Dependent
+public class ElasticResources {
+
+    @Inject
+    JestClientProvider jestClientProvider;
+
+    @Produces
+    @Default
+    JestClient getJestClient() {
+        return jestClientProvider.getJestClient();
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/ElasticServiceEJB.java
@@ -1,0 +1,165 @@
+package biz.karms.sinkit.ejb.elastic;
+
+import biz.karms.sinkit.exception.ArchiveException;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Index;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import io.searchbox.params.Parameters;
+
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Created by tkozel on 4.8.15.
+ */
+@Singleton
+public class ElasticServiceEJB {
+
+    public static final String ELASTIC_IOC_INDEX = "iocs";
+    public static final String ELASTIC_IOC_TYPE = "intelmq";
+    public static final String ELASTIC_LOG_INDEX = "logs";
+    public static final String ELASTIC_LOG_TYPE = "match";
+
+    private static final String PARAMETER_FROM = "from";
+    private static final int DEF_LIMIT = 1000;
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private JestClient elasticClient;
+
+    public JestClient getElasticClient() {
+        return elasticClient;
+    }
+
+    /**
+     * Searches index of given type using query for single object of class T
+     *
+     * @param query Elastic Search query in JSON format
+     * @param index Document index
+     * @param type Document type
+     * @param clazz Class of object being found
+     * @param <T> Class of object being found
+     * @return Found object of class T
+     * @throws ArchiveException when communication with elastic went wrong or more than single hit is found
+     */
+    public <T extends Indexable> T searchForSingleHit(
+            String query, String index, String type, Class<T> clazz) throws ArchiveException {
+
+        List<T> hits = this.search(query, index, type, clazz);
+
+        if (hits.isEmpty()) return null;
+        else if (hits.size() > 1) {
+            log.severe("Query returned more than single result: " + query);
+            throw new ArchiveException("Search returned " + hits.size() + " hits. Expecting max one -> panic!");
+        }
+        return hits.get(0);
+    }
+
+    /**
+     * Searches index of given type using query for objects of class T (max DEF_LIMIT of hits is returned)
+     *
+     * @param query Elastic Search query in JSON format
+     * @param index Document index
+     * @param type Document type
+     * @param clazz Class of object being found
+     * @param <T> Class of object being found
+     * @return Found objects of class T
+     * @throws ArchiveException when communication with elastic went wrong
+     */
+    public <T extends Indexable> List<T> search(String query, String index, String type, Class<T> clazz)
+            throws ArchiveException {
+
+        return search(query, index, type, 0, DEF_LIMIT, clazz);
+    }
+
+    /**
+     * Searches index of given type using query for objects of class T. Search returns max "size" objects and
+     * search starts at "from" offset
+     *
+     * @param query Elastic Search query in JSON format
+     * @param index Document index
+     * @param type Document type
+     * @param from Offset of search
+     * @param size limit of returned objects
+     * @param clazz Class of object being found
+     * @param <T> Class of object being found
+     * @return Found objects of class T
+     * @throws ArchiveException when communication with elastic went wrong
+     */
+    public <T extends Indexable> List<T> search(
+            String query, String index, String type, int from, int size, Class<T> clazz) throws ArchiveException {
+
+        Search search = new Search.Builder(query)
+                .addIndex(index)
+                .addType(type)
+                .setParameter(PARAMETER_FROM, from)
+                .setParameter(Parameters.SIZE, size)
+                .build();
+
+        //log.info("Searching archive with query: \n" + query);
+
+        SearchResult result;
+        try {
+            result = elasticClient.execute(search);
+        } catch (IOException e) {
+            throw new ArchiveException("Elastic search went wrong.", e);
+        }
+
+        if (!result.isSucceeded()) {
+            throw new ArchiveException(result.getErrorMessage());
+        }
+
+        //log.info("Found " + result.getTotal() + " hits");
+
+        //log.info(result.getJsonString());
+        if (result.getTotal() < 1) return new ArrayList<>();
+
+        return result.getSourceAsObjectList(clazz);
+    }
+
+    /**
+     * Stores object that implements Indexable interface
+     *
+     * @param document object being stored
+     * @param index Document index
+     * @param type Document type
+     * @param <T> Class of object being stored
+     * @return indexed object
+     * @throws ArchiveException when communication with Elastic Search server went wrong
+     */
+    public <T extends Indexable> T index(T document, String index, String type)
+            throws ArchiveException {
+
+        Index indexRequest = new Index.Builder(document)
+                .index(index)
+                .type(type)
+                .setParameter(Parameters.REFRESH, true)
+                .build();
+        //log.info("Indexing ioc [" + ioc.toString() + "]");
+
+        JestResult result;
+        try {
+            result = elasticClient.execute(indexRequest);
+        } catch (IOException e) {
+            throw new ArchiveException("Indexing IoC went wrong.", e);
+        }
+
+        if (result.isSucceeded()) {
+            String docId = result.getJsonObject().getAsJsonPrimitive("_id").getAsString();
+            document.setDocumentId(docId);
+            //log.info("Indexed ioc: [" + ioc.toString() + "]");
+        } else {
+            log.severe("Archive returned error: " + result.getErrorMessage());
+            throw new ArchiveException(result.getErrorMessage());
+        }
+        return document;
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/Indexable.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/Indexable.java
@@ -1,0 +1,13 @@
+package biz.karms.sinkit.ejb.elastic;
+
+import java.io.Serializable;
+
+/**
+ * Created by tkozel on 4.8.15.
+ */
+public interface Indexable extends Serializable {
+
+    public String getDocumentId();
+
+    public void setDocumentId(String documentId);
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/JestClientProvider.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/elastic/JestClientProvider.java
@@ -1,4 +1,4 @@
-package biz.karms.sinkit.ejb;
+package biz.karms.sinkit.ejb.elastic;
 
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestClientFactory;

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/VirusTotalClientProvider.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/VirusTotalClientProvider.java
@@ -1,0 +1,50 @@
+package biz.karms.sinkit.ejb.virustotal;
+
+import com.kanishka.virustotal.exception.APIKeyNotFoundException;
+import com.kanishka.virustotalv2.VirusTotalConfig;
+import com.kanishka.virustotalv2.VirustotalPublicV2;
+import com.kanishka.virustotalv2.VirustotalPublicV2Impl;
+
+import javax.ejb.Singleton;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.logging.Logger;
+
+/**
+ * Created by tkozel on 31.7.15.
+ */
+@ApplicationScoped
+@Singleton
+public class VirusTotalClientProvider {
+
+    //TODO move API_KEY TO env_prop
+    private static final String API_KEY = "6cdef8aad7ef5a4c8b0540c8c835bdace5ab288f50af555a77c5538189845227";
+
+    @Inject
+    private Logger log;
+
+    private VirustotalPublicV2 virusTotalClient;
+
+    /**
+     * returns (with lazy initialization) total virus client
+     *
+     * Exception is thrown by new VirustotalPublicV2Impl() only if api key is not set
+     * but VirusTotalConfig.getConfigInstance().setVirusTotalAPIKey(API_KEY) is called before
+     * so the exception can never be thrown
+     *
+     * @return VirustotalPublicV2 Total Virus client
+     * @throws APIKeyNotFoundException
+     */
+    public VirustotalPublicV2 getVirusTotalClient() throws APIKeyNotFoundException {
+
+        if (virusTotalClient == null) {
+
+            log.info("\n\n Virus Total client does not exist - constructing a new one\n\n");
+
+            VirusTotalConfig.getConfigInstance().setVirusTotalAPIKey(API_KEY);
+            virusTotalClient = new VirustotalPublicV2Impl();
+        }
+
+        return virusTotalClient;
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/VirusTotalEnricherEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/VirusTotalEnricherEJB.java
@@ -1,0 +1,197 @@
+package biz.karms.sinkit.ejb.virustotal;
+
+import biz.karms.sinkit.ejb.ArchiveServiceEJB;
+import biz.karms.sinkit.ejb.virustotal.exception.VirusTotalException;
+import biz.karms.sinkit.eventlog.EventLogRecord;
+import biz.karms.sinkit.eventlog.VirusTotalRequestStatus;
+import biz.karms.sinkit.exception.ArchiveException;
+import biz.karms.sinkit.ioc.IoCRecord;
+import biz.karms.sinkit.ioc.IoCVirusTotalReport;
+import com.kanishka.virustotal.dto.FileScanReport;
+import com.kanishka.virustotal.exception.InvalidArguentsException;
+import com.kanishka.virustotal.exception.QuotaExceededException;
+import com.kanishka.virustotal.exception.UnauthorizedAccessException;
+
+import javax.ejb.*;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Created by tkozel on 31.7.15.
+ */
+@Startup
+@Singleton
+@TransactionManagement(TransactionManagementType.BEAN)
+public class VirusTotalEnricherEJB {
+
+    // we can call the Virus Total API only 4 times per minute
+    private static final int SHOTS_PER_RUN = 4;
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private ArchiveServiceEJB archiveService;
+
+    @Inject
+    private VirusTotalServiceEJB virusTotalService;
+
+    @Schedule(hour = "*", minute = "*", second = "40", persistent = false)
+    @AccessTimeout(value = 30, unit = TimeUnit.SECONDS)
+    public synchronized void runEnrichmentProcess() {
+
+        int availableVTCalls = SHOTS_PER_RUN;
+
+        boolean reportRequestQueueEmpty = false;
+        try {
+            while (availableVTCalls > 0) {
+                if (!reportRequestQueueEmpty) {
+                    EventLogRecord reportRequest = archiveService.getLogRecordWaitingForVTReport();
+                    if (reportRequest != null) {
+                        availableVTCalls--;
+                        processUrlScanReportRequest(reportRequest);
+                        reportRequest.getVirusTotalRequest().setStatus(VirusTotalRequestStatus.FINISHED);
+                        reportRequest.getVirusTotalRequest().setReportReceived(new Date());
+                        archiveService.archiveEventLogRecord(reportRequest);
+                    } else {
+                        reportRequestQueueEmpty = true;
+                    }
+                } else {
+                    EventLogRecord scanRequest = archiveService.getLogRecordWaitingForVTScan();
+                    if (scanRequest != null) {
+
+                        boolean needEnrichment = false;
+                        availableVTCalls--;
+                        // the API is called here
+                        needEnrichment = processUrlScanRequest(scanRequest);
+
+                        if (needEnrichment) {
+                            scanRequest.getVirusTotalRequest().setStatus(VirusTotalRequestStatus.WAITING_FOR_REPORT);
+                        } else {
+                            scanRequest.getVirusTotalRequest().setStatus(VirusTotalRequestStatus.NOT_NEEDED);
+                        }
+                        scanRequest.getVirusTotalRequest().setProcessed(new Date());
+                        archiveService.archiveEventLogRecord(scanRequest);
+                    } else {
+                        // there is no record for waiting for processing nor waiting for report -> need to break the cycle
+                        break;
+                    }
+                }
+            }
+        } catch (QuotaExceededException e) {
+            log.warning("VirusTutotal enrichment: quota exceeded before than expected -> skipping next runs in batch");
+        } catch (ArchiveException|VirusTotalException e) {
+            log.severe("Virus Total enrichment went wrong: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private boolean processUrlScanRequest(final EventLogRecord enrichmentRequest) throws ArchiveException,
+            QuotaExceededException, VirusTotalException {
+
+        log.finest("Processing URL scan request: " + enrichmentRequest.toString());
+
+        String fqdn = enrichmentRequest.getReason().getFqdn();
+        boolean needEnrichment = false;
+        iocsLoop:
+        for (String iocId: enrichmentRequest.getMatchedIocs()) {
+            IoCRecord ioc = archiveService.getIoCRecordById(iocId);
+            if (ioc == null) {
+                log.warning("VirusTotal: IoC with id: " + iocId + " does not exist -> skipping scan request.");
+                continue;
+            } else {
+                log.finest("IoC found: " + ioc.toString());
+            }
+
+            if (ioc.getVirusTotalReports() == null || ioc.getVirusTotalReports().length == 0) {
+                log.finest("IoC does not have any VT reports yet -> FQDN will be scanned");
+                needEnrichment = true;
+                break;
+            } else {
+                boolean fqdnFound = false;
+                for (IoCVirusTotalReport report : ioc.getVirusTotalReports()) {
+                    if (fqdn.equals(report.getFqdn())) {
+                        log.finest("VT report for same FQDN found: " + report.toString());
+                        fqdnFound = true;
+                        // if fqdn was found in reports but the report is older than 24h we need enrichment
+                        Calendar timeWindow = Calendar.getInstance();
+                        timeWindow.add(Calendar.HOUR_OF_DAY, -24);
+
+                        if (timeWindow.after(report.getScanDate())) {
+                            log.finest("Report is too old -> FQDN will be scanned");
+                            needEnrichment = true;
+                            break iocsLoop;
+                        }
+                    }
+                }
+
+                // if fqdn was not found in reports we need enrichment
+                if (!fqdnFound) {
+                    needEnrichment = true;
+                    log.finest("VT report with the same FQDN was not found -> FQDN will be scanned");
+                    break;
+                }
+            }
+        }
+
+        if (needEnrichment) {
+            try {
+                virusTotalService.scanUrl("http://" + fqdn + "/");
+            } catch (InvalidArguentsException|UnauthorizedAccessException|IOException e){
+                throw new VirusTotalException(e);
+            }
+        } else {
+            log.finest("Enrichment is not needed.");
+        }
+
+        return needEnrichment;
+    }
+
+    private void processUrlScanReportRequest(final EventLogRecord enrichmentRequest) throws ArchiveException,
+            QuotaExceededException, VirusTotalException {
+
+        log.finest("Processing URL scan report request: " + enrichmentRequest.toString());
+
+        String fqdn = enrichmentRequest.getReason().getFqdn();
+
+        FileScanReport report;
+        try {
+          report = virusTotalService.getUrlScanReport("http://" + fqdn + "/");
+        } catch (InvalidArguentsException|UnauthorizedAccessException|IOException e){
+            throw new VirusTotalException(e);
+        }
+
+        IoCVirusTotalReport total = new IoCVirusTotalReport();
+        total.setFqdn(fqdn);
+        total.setUrlReport(report);
+        try {
+            total.setScanDate(virusTotalService.parseDate(report.getScanDate()));
+        } catch (ParseException e) {
+            throw new VirusTotalException("Cannot parse scan date of report: " + report.getScanDate(),e);
+        }
+
+        for (String iocId: enrichmentRequest.getMatchedIocs()) {
+            IoCRecord ioc = archiveService.getIoCRecordById(iocId);
+            if (ioc == null) {
+                log.warning("VirusTotal - IoC with id: " + iocId + " does not exist -> can't be enriched.");
+                continue;
+            }
+
+            if (ioc.getVirusTotalReports() == null || ioc.getVirusTotalReports().length == 0) {
+                ioc.setVirusTotalReports(new IoCVirusTotalReport[]{total});
+                log.finest("IoC does not have any report yet -> adding new one");
+            } else {
+                List<IoCVirusTotalReport> reportsList = new ArrayList<IoCVirusTotalReport>(Arrays.asList(ioc.getVirusTotalReports()));
+                reportsList.add(total);
+                ioc.setVirusTotalReports(reportsList.toArray(new IoCVirusTotalReport[reportsList.size()]));
+
+                log.finest("IoC does have some reports already -> adding new one");
+            }
+            archiveService.archiveIoCRecord(ioc);
+        }
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/VirusTotalResources.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/VirusTotalResources.java
@@ -1,0 +1,29 @@
+package biz.karms.sinkit.ejb.virustotal;
+
+import com.kanishka.virustotal.exception.APIKeyNotFoundException;
+import com.kanishka.virustotalv2.VirustotalPublicV2;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+/**
+ * Created by tkozel on 4.8.15.
+ */
+@Dependent
+public class VirusTotalResources {
+
+    @Inject
+    VirusTotalClientProvider virusTotalClientProvider;
+
+    /**
+     * For more info about exception
+     * @see VirusTotalClientProvider
+     */
+    @Produces
+    @Default
+    VirustotalPublicV2 getVirusTotalClient() throws APIKeyNotFoundException {
+        return virusTotalClientProvider.getVirusTotalClient();
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/VirusTotalServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/VirusTotalServiceEJB.java
@@ -1,0 +1,67 @@
+package biz.karms.sinkit.ejb.virustotal;
+
+import com.kanishka.virustotal.dto.FileScanReport;
+import com.kanishka.virustotal.dto.ScanInfo;
+import com.kanishka.virustotal.exception.InvalidArguentsException;
+import com.kanishka.virustotal.exception.QuotaExceededException;
+import com.kanishka.virustotal.exception.UnauthorizedAccessException;
+import com.kanishka.virustotalv2.VirustotalPublicV2;
+
+import javax.ejb.Singleton;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Logger;
+
+/**
+ * Created by tkozel on 31.7.15.
+ */
+@Singleton
+public class VirusTotalServiceEJB {
+
+    private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+    @Inject
+    private Logger log;
+
+    @Inject
+    private VirustotalPublicV2 virusTotalClient;
+
+    public ScanInfo scanUrl(String url) throws QuotaExceededException,
+            InvalidArguentsException, UnauthorizedAccessException, IOException {
+
+        log.finest("VT scanning URL: " + url);
+        ScanInfo[] scanInfoArr = virusTotalClient.scanUrls(new String[]{url});
+//        for (ScanInfo scanInformation : scanInfoArr) {
+//            log.info("___SCAN INFORMATION___");
+//            log.info("MD5 :\t" + scanInformation.getMd5());
+//            log.info("Perma Link :\t" + scanInformation.getPermalink());
+//            log.info("Resource :\t" + scanInformation.getResource());
+//            log.info("Scan Date :\t" + scanInformation.getScanDate());
+//            log.info("Scan Id :\t" + scanInformation.getScanId());
+//            log.info("SHA1 :\t" + scanInformation.getSha1());
+//            log.info("SHA256 :\t" + scanInformation.getSha256());
+//            log.info("Verbose Msg :\t" + scanInformation.getVerboseMessage());
+//            log.info("Response Code :\t" + scanInformation.getResponseCode());
+//            log.info("done.");
+//        }
+        return scanInfoArr[0];
+    }
+
+    public FileScanReport getUrlScanReport(String url) throws QuotaExceededException,
+            InvalidArguentsException, UnauthorizedAccessException, IOException {
+
+        log.finest("VT getting report of URL scan for UR: " + url);
+        FileScanReport[] reports = virusTotalClient.getUrlScanReport(new String[]{url}, false);
+
+        return reports[0];
+    }
+
+    public Date parseDate(String date) throws ParseException {
+        DateFormat df = new SimpleDateFormat(DATE_FORMAT);
+        return df.parse(date);
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/exception/VirusTotalException.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/virustotal/exception/VirusTotalException.java
@@ -1,0 +1,26 @@
+package biz.karms.sinkit.ejb.virustotal.exception;
+
+/**
+ * Created by tkozel on 4.8.15.
+ */
+public class VirusTotalException extends Exception {
+    public VirusTotalException() {
+        super();
+    }
+
+    public VirusTotalException(String message) {
+        super(message);
+    }
+
+    public VirusTotalException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public VirusTotalException(Throwable cause) {
+        super(cause);
+    }
+
+    protected VirusTotalException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/eventlog/EventDNSRequest.java
+++ b/ejb/src/main/java/biz/karms/sinkit/eventlog/EventDNSRequest.java
@@ -1,9 +1,13 @@
 package biz.karms.sinkit.eventlog;
 
+import java.io.Serializable;
+
 /**
  * Created by tkozel on 23.7.15.
  */
-public class EventDNSRequest {
+public class EventDNSRequest implements Serializable {
+
+    private static final long serialVersionUID = -8270442960082815073L;
 
     private String ip;
     private String raw;

--- a/ejb/src/main/java/biz/karms/sinkit/eventlog/EventLogRecord.java
+++ b/ejb/src/main/java/biz/karms/sinkit/eventlog/EventLogRecord.java
@@ -1,15 +1,21 @@
 package biz.karms.sinkit.eventlog;
 
+import biz.karms.sinkit.ejb.elastic.Indexable;
 import com.google.gson.annotations.SerializedName;
+import io.searchbox.annotations.JestId;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Date;
 
 /**
  * Created by tkozel on 23.7.15.
  */
-public class EventLogRecord implements Serializable {
+public class EventLogRecord implements Indexable {
+
+    private static final long serialVersionUID = 423449239443309837L;
+
+    @JestId
+    private transient String documentId;
 
     private EventLogAction action;
     private String client;
@@ -17,8 +23,19 @@ public class EventLogRecord implements Serializable {
     private EventReason reason;
     private Date logged;
 
+    @SerializedName("virus_total_request")
+    private VirusTotalRequest virusTotalRequest;
+
     @SerializedName("matched_iocs")
     private String[] matchedIocs;
+
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    public void setDocumentId(String documentId) {
+        this.documentId = documentId;
+    }
 
     public EventLogAction getAction() {
         return action;
@@ -60,6 +77,14 @@ public class EventLogRecord implements Serializable {
         this.logged = logged;
     }
 
+    public VirusTotalRequest getVirusTotalRequest() {
+        return virusTotalRequest;
+    }
+
+    public void setVirusTotalRequest(VirusTotalRequest virusTotalRequest) {
+        this.virusTotalRequest = virusTotalRequest;
+    }
+
     public String[] getMatchedIocs() {
         return matchedIocs;
     }
@@ -71,11 +96,13 @@ public class EventLogRecord implements Serializable {
     @Override
     public String toString() {
         return "EventLogRecord{" +
-                "action=" + action +
+                "documentId='" + documentId + '\'' +
+                ", action=" + action +
                 ", client='" + client + '\'' +
                 ", request=" + request +
                 ", reason=" + reason +
                 ", logged=" + logged +
+                ", virusTotalRequest=" + virusTotalRequest +
                 ", matchedIocs=" + Arrays.toString(matchedIocs) +
                 '}';
     }

--- a/ejb/src/main/java/biz/karms/sinkit/eventlog/EventReason.java
+++ b/ejb/src/main/java/biz/karms/sinkit/eventlog/EventReason.java
@@ -7,6 +7,8 @@ import java.io.Serializable;
  */
 public class EventReason implements Serializable {
 
+    private static final long serialVersionUID = 8092255064427923820L;
+
     private String fqdn;
     private String ip;
 

--- a/ejb/src/main/java/biz/karms/sinkit/eventlog/VirusTotalRequest.java
+++ b/ejb/src/main/java/biz/karms/sinkit/eventlog/VirusTotalRequest.java
@@ -1,0 +1,55 @@
+package biz.karms.sinkit.eventlog;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Created by tkozel on 3.8.15.
+ */
+public class VirusTotalRequest implements Serializable {
+
+    private static final long serialVersionUID = -6504838382962619288L;
+
+    private VirusTotalRequestStatus status;
+
+    @SerializedName("processed")
+    private Date processed;
+
+    @SerializedName("report_received")
+    private Date reportReceived;
+
+    public VirusTotalRequestStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VirusTotalRequestStatus status) {
+        this.status = status;
+    }
+
+    public Date getProcessed() {
+        return processed;
+    }
+
+    public void setProcessed(Date processed) {
+        this.processed = processed;
+    }
+
+    public Date getReportReceived() {
+        return reportReceived;
+    }
+
+    public void setReportReceived(Date reportReceived) {
+        this.reportReceived = reportReceived;
+    }
+
+    @Override
+    public String toString() {
+        return "VirusTotalRequest{" +
+                "status=" + status +
+                ", processed=" + processed +
+                ", reportReceived=" + reportReceived +
+                '}';
+    }
+}

--- a/ejb/src/main/java/biz/karms/sinkit/eventlog/VirusTotalRequestStatus.java
+++ b/ejb/src/main/java/biz/karms/sinkit/eventlog/VirusTotalRequestStatus.java
@@ -1,0 +1,27 @@
+package biz.karms.sinkit.eventlog;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Created by tkozel on 3.8.15.
+ */
+public enum VirusTotalRequestStatus {
+
+    // initial state of Virus Total request, it's waiting for processing
+    @SerializedName("waiting")
+    WAITING,
+
+    // Virus Total has already been asked for scan of given URL and the request is now waiting for report
+    @SerializedName("waiting_for_report")
+    WAITING_FOR_REPORT,
+
+    // the request is finished, VirusTotal report has been received and corresponding IoCs were enriched
+    // this is end state
+    @SerializedName("finished")
+    FINISHED,
+
+    // there is already actual report from Virus Total in Core and it's not necessary to ask Virus Total
+    // this is end state
+    @SerializedName("not_needed")
+    NOT_NEEDED
+}

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCClassification.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCClassification.java
@@ -8,15 +8,11 @@ import java.io.Serializable;
 /**
  * Created by tkozel on 24.6.15.
  */
-@Indexed
 public class IoCClassification implements Serializable {
 
-    private static final long serialVersionUID = 2184815523047755694L;
+    private static final long serialVersionUID = -5807317040203145173L;
 
-    @Field
     private String type;
-
-    @Field
     private String taxonomy;
 
     public IoCClassification() {}

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCDescription.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCDescription.java
@@ -1,19 +1,14 @@
 package biz.karms.sinkit.ioc;
 
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-
 import java.io.Serializable;
 
 /**
  * Created by tkozel on 24.6.15.
  */
-@Indexed
 public class IoCDescription implements Serializable {
 
-    private static final long serialVersionUID = 2184815523047755693L;
+    private static final long serialVersionUID = -2234084703962020531L;
 
-    @Field
     private String text;
 
     public IoCDescription() {}

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCFeed.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCFeed.java
@@ -1,22 +1,15 @@
 package biz.karms.sinkit.ioc;
 
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-
 import java.io.Serializable;
 
 /**
  * Created by tkozel on 24.6.15.
  */
-@Indexed
 public class IoCFeed implements Serializable {
 
-    private static final long serialVersionUID = 2184815523047755692L;
+    private static final long serialVersionUID = -5066334431395905204L;
 
-    @Field
     private String url;
-
-    @Field
     private String name;
 
     public IoCFeed() {}

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCGeolocation.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCGeolocation.java
@@ -1,33 +1,18 @@
 package biz.karms.sinkit.ioc;
 
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-import org.hibernate.search.annotations.NumericField;
-
 import java.io.Serializable;
 
 /**
  * Created by tkozel on 25.6.15.
  */
-@Indexed
 public class IoCGeolocation implements Serializable {
 
-    private static final long serialVersionUID = 2184815523047755698L;
+    private static final long serialVersionUID = -7300830254275899055L;
 
-    @Field
     private String cc;
-
-    @Field
     private String city;
-
-    @Field
-    @NumericField
     private Float latitude;
-
-    @Field
-    @NumericField
     private Float longitude;
-
 
     public String getCc() {
         return cc;

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCProtocol.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCProtocol.java
@@ -1,17 +1,14 @@
 package biz.karms.sinkit.ioc;
 
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
+import java.io.Serializable;
 
 /**
  * Created by tkozel on 25.6.15.
  */
-@Indexed
-public class IoCProtocol {
+public class IoCProtocol implements Serializable {
 
-    private static final long serialVersionUID = 2184815523047755698L;
+    private static final long serialVersionUID = -5416774385239247512L;
 
-    @Field
     private String application;
 
     public String getApplication() {

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCRecord.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCRecord.java
@@ -1,53 +1,34 @@
 package biz.karms.sinkit.ioc;
 
+import biz.karms.sinkit.ejb.elastic.Indexable;
 import com.google.gson.annotations.SerializedName;
 import io.searchbox.annotations.JestId;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
 
-import java.io.Serializable;
-import java.lang.annotation.ElementType;
-import java.util.Calendar;
+import java.util.Arrays;
 
 /**
  * Created by tkozel on 24.6.15.
  */
-@Indexed
-public class IoCRecord implements Serializable {
+public class IoCRecord implements Indexable {
 
     public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";
 
-    private static final long serialVersionUID = 2184815523047755697L;
+    private static final long serialVersionUID = -595246622767555283L;
 
     @JestId
     private transient String documentId;
-
-    @Field
     private IoCFeed feed;
-
-    @Field
     private IoCDescription description;
-
-    @Field
     private IoCClassification classification;
-
-    @Field
     private IoCProtocol protocol;
-
-    @Field
     private String raw;
-
-    @Field
     private IoCSource source;
-
-    @Field
     private IoCTime time;
-
-    @Field
     private IoCSeen seen;
-
-    @Field
     private boolean active;
+
+    @SerializedName("virus_total_reports")
+    private IoCVirusTotalReport[] virusTotalReports;
 
     public IoCRecord() {}
 
@@ -131,6 +112,14 @@ public class IoCRecord implements Serializable {
         this.active = active;
     }
 
+    public IoCVirusTotalReport[] getVirusTotalReports() {
+        return virusTotalReports;
+    }
+
+    public void setVirusTotalReports(IoCVirusTotalReport[] virusTotalReports) {
+        this.virusTotalReports = virusTotalReports;
+    }
+
     @Override
     public String toString() {
         return "IoCRecord{" +
@@ -144,6 +133,7 @@ public class IoCRecord implements Serializable {
                 ", time=" + time +
                 ", seen=" + seen +
                 ", active=" + active +
+                ", virusTotalReports=" + Arrays.toString(virusTotalReports) +
                 '}';
     }
 }

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSeen.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSeen.java
@@ -1,24 +1,16 @@
 package biz.karms.sinkit.ioc;
 
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-
 import java.io.Serializable;
 import java.util.Date;
 
 /**
  * Created by tkozel on 25.6.15.
  */
-
-@Indexed
 public class IoCSeen implements Serializable {
 
-    private static final long serialVersionUID = 2184815523047755699L;
+    private static final long serialVersionUID = -8503565375996995715L;
 
-    @Field
     private Date first;
-
-    @Field
     private Date last;
 
     public Date getFirst() {

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSource.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSource.java
@@ -1,8 +1,6 @@
 package biz.karms.sinkit.ioc;
 
 import com.google.gson.annotations.SerializedName;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.NumericField;
 
 import java.io.Serializable;
@@ -10,39 +8,26 @@ import java.io.Serializable;
 /**
  * Created by tkozel on 24.6.15.
  */
-@Indexed
 public class IoCSource implements Serializable {
 
-    private static final long serialVersionUID = 2184815523047755695L;
+    private static final long serialVersionUID = 6742947300724661734L;
 
-    @Field
     private IoCSourceId id;
-
-    @Field
     private String url;
-
-    @Field
     private String ip;
-
-    @Field
     private String fqdn;
 
-    @Field
     @SerializedName("reverse_domain_name")
     private String reverseDomainName;
 
-    @Field
     @NumericField
     private Integer asn;
 
-    @Field
     @SerializedName("asn_name")
     private String asnName;
 
-    @Field
     private IoCGeolocation geolocation;
 
-    @Field
     @SerializedName("bgp_prefix")
     private String bgpPrefix;
 

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSourceId.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCSourceId.java
@@ -1,22 +1,18 @@
 package biz.karms.sinkit.ioc;
 
 import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
 
 import java.io.Serializable;
 
 /**
  * Created by tkozel on 10.7.15.
  */
-@Indexed
+
 public class IoCSourceId implements Serializable {
 
-    private static final long serialVersionUID = 2184815523040755395L;
+    private static final long serialVersionUID = 2510134193901542038L;
 
-    @Field
     private String value;
-
-    @Field
     private IoCSourceIdType type;
 
     public String getValue() {

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCTime.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCTime.java
@@ -4,21 +4,14 @@ package biz.karms.sinkit.ioc;
  * Created by tkozel on 24.6.15.
  */
 
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.Indexed;
-
 import java.io.Serializable;
 import java.util.Date;
 
-@Indexed
 public class IoCTime implements Serializable {
 
-    private static final long serialVersionUID = 2184815523047755696L;
+    private static final long serialVersionUID = 3518598035766322842L;
 
-    @Field
     private Date source;
-
-    @Field
     private Date observation;
 
     public Date getSource() {

--- a/ejb/src/main/java/biz/karms/sinkit/ioc/IoCVirusTotalReport.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ioc/IoCVirusTotalReport.java
@@ -1,0 +1,56 @@
+package biz.karms.sinkit.ioc;
+
+import com.google.gson.annotations.SerializedName;
+import com.kanishka.virustotal.dto.FileScanReport;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Created by tkozel on 31.7.15.
+ */
+public class IoCVirusTotalReport implements Serializable {
+
+    private static final long serialVersionUID = -3335848811246446743L;
+
+    private String fqdn;
+
+    @SerializedName("scan_date")
+    private Date scanDate;
+
+    @SerializedName("url_report")
+    private FileScanReport urlReport;
+
+    public String getFqdn() {
+        return fqdn;
+    }
+
+    public void setFqdn(String fqdn) {
+        this.fqdn = fqdn;
+    }
+
+    public Date getScanDate() {
+        return scanDate;
+    }
+
+    public void setScanDate(Date scanDate) {
+        this.scanDate = scanDate;
+    }
+
+    public FileScanReport getUrlReport() {
+        return urlReport;
+    }
+
+    public void setUrlReport(FileScanReport urlReport) {
+        this.urlReport = urlReport;
+    }
+
+    @Override
+    public String toString() {
+        return "IoCVirusTotalReport{" +
+                "fqdn='" + fqdn + '\'' +
+                ", scanDate=" + scanDate +
+                ", urlReport=" + urlReport +
+                '}';
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,9 @@
         <!-- Elastic Search -->
         <io.searchbox.jest.version>0.1.6</io.searchbox.jest.version>
 
+        <!-- Virus Total -->
+        <com.kanishka.api.VirustotalPublicV2.0.version>1.1.GA-SNAPSHOT</com.kanishka.api.VirustotalPublicV2.0.version>
+
         <!-- Infinispan and business core deps-->
         <infinispan.core.version>7.2.3.Final</infinispan.core.version>
         <infinispan.cachestore.jdbc.version>7.2.3.Final</infinispan.cachestore.jdbc.version>

--- a/rest/src/main/java/biz/karms/sinkit/rest/SinkitREST.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/SinkitREST.java
@@ -2,10 +2,14 @@ package biz.karms.sinkit.rest;
 
 import biz.karms.sinkit.exception.IoCValidationException;
 import com.google.gson.JsonSyntaxException;
+import com.kanishka.virustotal.exception.InvalidArguentsException;
+import com.kanishka.virustotal.exception.QuotaExceededException;
+import com.kanishka.virustotal.exception.UnauthorizedAccessException;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.util.logging.Logger;
 
 /**
@@ -110,7 +114,7 @@ public class SinkitREST {
     @POST
     @Path("/blacklist/ioc/")
     @Produces({"application/json;charset=UTF-8"})
-    @Consumes({"application/json;charset=UTF-8"})
+    //@Consumes({"application/json;charset=UTF-8"})
     public Response putIoCRecord(@HeaderParam(AUTH_HEADER_PARAM) String token, String ioc) {
 
         if (!stupidAuthenticator.isAuthenticated(token)) {
@@ -218,4 +222,35 @@ public class SinkitREST {
         }
     }
 
+    @POST
+    @Path("/log/record")
+    public String logRecrod(@HeaderParam(AUTH_HEADER_PARAM) String token, String logRecord) {
+        if (stupidAuthenticator.isAuthenticated(token)) {
+            try {
+                sinkitService.addEventLogRecord(logRecord);
+                return "OK";
+            } catch (Exception e) {
+                e.printStackTrace();
+                return "Not Ok";
+            }
+        } else {
+            return AUTH_FAIL;
+        }
+    }
+
+    @POST
+    @Path("/total/enrich")
+    public String enrich(@HeaderParam(AUTH_HEADER_PARAM) String token) {
+        if (stupidAuthenticator.isAuthenticated(token)) {
+            try {
+                sinkitService.enrich();
+                return "OK";
+            } catch (Exception e) {
+                e.printStackTrace();
+                return "Not Ok";
+            }
+        } else {
+            return AUTH_FAIL;
+        }
+    }
 }

--- a/rest/src/main/java/biz/karms/sinkit/rest/SinkitService.java
+++ b/rest/src/main/java/biz/karms/sinkit/rest/SinkitService.java
@@ -7,6 +7,7 @@ import biz.karms.sinkit.ejb.WebApiEJB;
 import biz.karms.sinkit.ejb.dto.AllDNSSettingDTO;
 import biz.karms.sinkit.ejb.dto.CustomerCustomListDTO;
 import biz.karms.sinkit.ejb.dto.FeedSettingCreateDTO;
+import biz.karms.sinkit.eventlog.EventLogRecord;
 import biz.karms.sinkit.exception.ArchiveException;
 import biz.karms.sinkit.exception.IoCValidationException;
 import biz.karms.sinkit.ioc.IoCRecord;
@@ -18,6 +19,7 @@ import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import java.io.Serializable;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -193,5 +195,21 @@ public class SinkitService implements Serializable {
             log.log(Level.SEVERE, "postCreateFeedSettings", e);
             return new GsonBuilder().create().toJson(ERR_MSG);
         }
+    }
+
+    void addEventLogRecord(final String json) throws ArchiveException {
+        EventLogRecord logRec = new GsonBuilder().create().fromJson(json, EventLogRecord.class);
+        coreService.logEvent(
+                logRec.getAction(),
+                logRec.getClient(),
+                logRec.getRequest().getIp(),
+                logRec.getRequest().getRaw(),
+                logRec.getReason().getFqdn(),
+                logRec.getReason().getIp(),
+                logRec.getMatchedIocs());
+    }
+
+    public void enrich() {
+        coreService.enrich();
     }
 }


### PR DESCRIPTION
Quite big branch contains functionality for enrichment from Virus Total service and some refactoring.

- for development: the VirusTotal client library has to be installed in local maven repository. Follow "Getting started" section in http://kdkanishka.github.io/Virustotal-Public-API-V2.0-Client/
- main duty of Virus Total logic ensure VirusTotalServiceEJB (provides connection to Virus Total service) and VirusTotalEnricherEJB (reads the queue of logged EventLogRecords and according to them it enriches IoCRecords with Virus Total report)
- since now Virus Total and Elastic Search logic has their own packages
- Elastic Search service was divided into to EJBs:
  - ElasticServiceEJB - serves generic requests (CRUDs over objects implementing Indexable interface), resides in elastic package
  - ArchiveServiceEJB serves specific requests for Core logic (uses ElasticServiceEJB internally)
- object that can be indexed in Elastic Search has to implement Indexable interface (implementing classes are IoCRecord and EventLogRecord at the moment)
- both components (Virus Total and Elastic Search) have their own resource providers 
-  unused annotations were removed from IoCs DTOs
