### PR TITLE
Support for automatic indices creation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,8 +27,6 @@ dependencies:
     - git clone https://github.com/kdkanishka/Virustotal-Public-API-V2.0-Client.git && pushd Virustotal-Public-API-V2.0-Client/ && mvn install -DskipTests && popd
     - curl -XPUT localhost:9200/_template/iocs -d @integration-tests/src/test/resources/elastic_iocs.json
     - curl -XPUT localhost:9200/_template/logs -d @integration-tests/src/test/resources/elastic_logs.json
-    - curl -XPUT localhost:9200/iocs/
-    - curl -XPUT localhost:9200/logs/
 test:
   override:
     - mvn clean install -Parq-wildfly-managed

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/ArchiveServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/ArchiveServiceEJB.java
@@ -38,14 +38,10 @@ public class ArchiveServiceEJB {
     private ElasticServiceEJB elasticService;
 
     @PostConstruct
-    public void setup() throws ArchiveException {
+    public void setup() {
         if (elasticService == null) {
             throw new IllegalArgumentException("ElasticServiceEJB must be injected.");
         }
-
-        //create indices if don't exist
-        elasticService.createIndex(ELASTIC_IOC_INDEX);
-        elasticService.createIndex(ELASTIC_LOG_INDEX);
     }
 
     public IoCRecord findActiveIoCRecordBySourceId(

--- a/integration-tests/src/test/java/biz/karms/sinkit/tests/api/ApiIntegrationTest.java
+++ b/integration-tests/src/test/java/biz/karms/sinkit/tests/api/ApiIntegrationTest.java
@@ -5,7 +5,11 @@ import biz.karms.sinkit.ejb.*;
 import biz.karms.sinkit.tests.util.IoCFactory;
 import biz.karms.sinkit.ioc.IoCRecord;
 import biz.karms.sinkit.ioc.IoCSourceIdType;
-import com.gargoylesoftware.htmlunit.*;
+import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.Page;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -38,7 +42,7 @@ public class ApiIntegrationTest extends Arquillian {
     @Deployment(name = "ear", testable = true)
     public static Archive<?> createTestArchive() {
         EnterpriseArchive ear = ShrinkWrap.create(ZipImporter.class, "sinkit-ear.ear").importFrom(new File("../ear/target/sinkit-ear.ear")).as(EnterpriseArchive.class);
-        ear.getAsType(JavaArchive.class, "sinkit-ejb.jar").addClass(ApiIntegrationTest.class).addClass(IoCFactory.class);
+        ear.getAsType(JavaArchive.class, "sinkit-ejb.jar").addClass(ApiIntegrationTest.class).addClass(IoCFactory.class).addClass(FailingHttpStatusCodeException.class);
         return ear;
     }
 
@@ -205,17 +209,7 @@ public class ApiIntegrationTest extends Arquillian {
         try {
             page = webClient.getPage(requestSettings);
             assertEquals(200, page.getWebResponse().getStatusCode());
-        } catch (Exception ex) {
-            //NO-OP index does not exist yet, but it's ok
-        }
-
-        requestSettings = new WebRequest(
-                new URL("http://" + System.getenv("SINKIT_ELASTIC_HOST") + ":" + System.getenv("SINKIT_ELASTIC_PORT") +
-                        "/" + ArchiveServiceEJB.ELASTIC_LOG_INDEX + "/"), HttpMethod.DELETE);
-        try {
-            page = webClient.getPage(requestSettings);
-            assertEquals(200, page.getWebResponse().getStatusCode());
-        } catch (Exception ex) {
+        } catch (FailingHttpStatusCodeException ex) {
             //NO-OP index does not exist yet, but it's ok
         }
     }


### PR DESCRIPTION
The core logic doesn't care about Archive indices and relies on automatic index creation during indexation of first document of given index. 
Search on index, that doesn't exist yet, doesn't throw MissingIndexException but it's considered to be "no hits found" situation and empty result is returned (warning about missing index is logged). 