### PR TITLE
#65 - Logging request fqdn and type

### DIFF
--- a/ejb/src/main/java/biz/karms/sinkit/ejb/DNSApi.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/DNSApi.java
@@ -29,7 +29,8 @@ public interface DNSApi {
             EventLogAction action,
             String clientUid,
             String requestIp,
-            String requestRaw,
+            String requestFqdn,
+            String requestType,
             String reasonFqdn,
             String reasonIp,
             Set<String> matchedIoCs

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/DNSApiEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/DNSApiEJB.java
@@ -322,7 +322,7 @@ public class DNSApiEJB implements DNSApi {
             log.log(Level.WARNING, "getSinkHole: Sinkhole.");
             try {
                 log.log(Level.FINE, "getSinkHole: Calling coreService.logDNSEvent(EventLogAction.BLOCK,...");
-                logDNSEvent(EventLogAction.BLOCK, String.valueOf(customerId), clientIPAddress, null, (isFQDN) ? fqdnOrIp : null, (isFQDN) ? null : fqdnOrIp, unwrapDocumentIds(feedTypeMap.values()));
+                logDNSEvent(EventLogAction.BLOCK, String.valueOf(customerId), clientIPAddress, null, (isFQDN) ? fqdnOrIp : null, null, (isFQDN) ? null : fqdnOrIp, unwrapDocumentIds(feedTypeMap.values()));
                 log.log(Level.FINE, "getSinkHole: coreService.logDNSEvent returned.");
             } catch (ArchiveException e) {
                 log.log(Level.SEVERE, "getSinkHole: Logging BLOCK failed: ", e);
@@ -333,7 +333,7 @@ public class DNSApiEJB implements DNSApi {
             //Log it for customer
             log.log(Level.WARNING, "getSinkHole: Log.");
             try {
-                logDNSEvent(EventLogAction.AUDIT, String.valueOf(customerId), clientIPAddress, null, (isFQDN) ? fqdnOrIp : null, (isFQDN) ? null : fqdnOrIp, unwrapDocumentIds(feedTypeMap.values()));
+                logDNSEvent(EventLogAction.AUDIT, String.valueOf(customerId), clientIPAddress, null, null, (isFQDN) ? fqdnOrIp : null, (isFQDN) ? null : fqdnOrIp, unwrapDocumentIds(feedTypeMap.values()));
             } catch (ArchiveException e) {
                 log.log(Level.SEVERE, "getSinkHole: Logging AUDIT failed: ", e);
             } finally {
@@ -344,7 +344,7 @@ public class DNSApiEJB implements DNSApi {
             //Log it for us
             log.log(Level.WARNING, "getSinkHole: Log internally.");
             try {
-                logDNSEvent(EventLogAction.INTERNAL, String.valueOf(customerId), clientIPAddress, null, (isFQDN) ? fqdnOrIp : null, (isFQDN) ? null : fqdnOrIp, unwrapDocumentIds(feedTypeMap.values()));
+                logDNSEvent(EventLogAction.INTERNAL, String.valueOf(customerId), clientIPAddress, null, null, (isFQDN) ? fqdnOrIp : null, (isFQDN) ? null : fqdnOrIp, unwrapDocumentIds(feedTypeMap.values()));
             } catch (ArchiveException e) {
                 log.log(Level.SEVERE, "getSinkHole: Logging INTERNAL failed: ", e);
             } finally {
@@ -367,17 +367,19 @@ public class DNSApiEJB implements DNSApi {
             EventLogAction action,
             String clientUid,
             String requestIp,
-            String requestRaw,
+            String requestFqdn,
+            String requestType,
             String reasonFqdn,
             String reasonIp,
             Set<String> matchedIoCs
     ) throws ArchiveException {
-        log.log(Level.FINE, "Logging DNS event. clientUid: " + clientUid + ", requestIp: " + requestIp + ", requestRaw: " + requestRaw + ", reasonFqdn: " + reasonFqdn + ", reasonIp: " + reasonIp);
+        log.log(Level.FINE, "Logging DNS event. clientUid: " + clientUid + ", requestIp: " + requestIp + ", requestFqdn: " + requestFqdn + ", requestType: " + requestType + ", reasonFqdn: " + reasonFqdn + ", reasonIp: " + reasonIp);
         EventLogRecord logRecord = new EventLogRecord();
 
         EventDNSRequest request = new EventDNSRequest();
         request.setIp(requestIp);
-        request.setRaw(requestRaw);
+        request.setFqdn(requestFqdn);
+        request.setType(requestType);
         logRecord.setRequest(request);
 
         EventReason reason = new EventReason();

--- a/ejb/src/main/java/biz/karms/sinkit/eventlog/EventDNSRequest.java
+++ b/ejb/src/main/java/biz/karms/sinkit/eventlog/EventDNSRequest.java
@@ -10,7 +10,8 @@ public class EventDNSRequest implements Serializable {
     private static final long serialVersionUID = -8270442960082815073L;
 
     private String ip;
-    private String raw;
+    private String fqdn;
+    private String type;
 
     public String getIp() {
         return ip;
@@ -20,19 +21,28 @@ public class EventDNSRequest implements Serializable {
         this.ip = ip;
     }
 
-    public String getRaw() {
-        return raw;
+    public String getFqdn() {
+        return fqdn;
     }
 
-    public void setRaw(String raw) {
-        this.raw = raw;
+    public void setFqdn(String fqdn) {
+        this.fqdn = fqdn;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     @Override
     public String toString() {
         return "EventDNSRequest{" +
                 "ip='" + ip + '\'' +
-                ", raw='" + raw + '\'' +
+                ", fqdn='" + fqdn + '\'' +
+                ", type='" + type + '\'' +
                 '}';
     }
 }

--- a/integration-tests/src/test/java/biz/karms/sinkit/tests/core/CoreTest.java
+++ b/integration-tests/src/test/java/biz/karms/sinkit/tests/core/CoreTest.java
@@ -194,7 +194,8 @@ public class CoreTest extends Arquillian {
         Future a = dnsApi.logDNSEvent(EventLogAction.BLOCK,
                 "10.1.1.1",
                 "10.1.1.2",
-                "requestRaw",
+                "requestFqdn",
+                "requestType",
                 "seznam.cz",
                 "10.1.1.3",
                 new HashSet<String>(Arrays.asList(iocId1,iocId2))
@@ -224,7 +225,8 @@ public class CoreTest extends Arquillian {
                         "                   \"query\": \"action : \\\"block\\\" AND " +
                         "                       client : \\\"10.1.1.1\\\" AND " +
                         "                       request.ip : \\\"10.1.1.2\\\" AND " +
-                        "                       request.raw : \\\"requestRaw\\\" AND " +
+                        "                       request.fqdn : \\\"requestFqdn\\\" AND " +
+                        "                       request.type : \\\"requestType\\\" AND " +
                         "                       reason.fqdn : \\\"seznam.cz\\\" AND " +
                         "                       reason.ip : \\\"10.1.1.3\\\"\"\n" +
                         "               }\n" +
@@ -247,7 +249,8 @@ public class CoreTest extends Arquillian {
         assertEquals(logRecord.get("action").getAsString(), "block");
         assertEquals(logRecord.get("client").getAsString(), "10.1.1.1");
         assertEquals(logRecord.get("request").getAsJsonObject().get("ip").getAsString(), "10.1.1.2");
-        assertEquals(logRecord.get("request").getAsJsonObject().get("raw").getAsString(), "requestRaw");
+        assertEquals(logRecord.get("request").getAsJsonObject().get("fqdn").getAsString(), "requestFqdn");
+        assertEquals(logRecord.get("request").getAsJsonObject().get("type").getAsString(), "requestType");
         assertEquals(logRecord.get("reason").getAsJsonObject().get("fqdn").getAsString(), "seznam.cz");
         assertEquals(logRecord.get("reason").getAsJsonObject().get("ip").getAsString(), "10.1.1.3");
         assertNotNull(logRecord.get("logged").getAsString());


### PR DESCRIPTION
#65 - logging extended of request.type and request.fqdn fields

@Karm in DNSApiEJB.java modify all calls of 
```
logDNSEvent(EventLogAction.AUDIT, String.valueOf(customerId), clientIPAddress, null, null, (isFQDN) ? fqdnOrIp : null, (isFQDN) ? null : fqdnOrIp, unwrapDocumentIds(feedTypeMap.values()));
```
instead of null (4th param) should be request.fqdn (String)
instead of null (5th param) should be request.type (yet String, but can be Enum if the set of values is finite)

note: since request.raw was deprecated it has been removed