### PR TITLE
Cache names are handled by static properties instead of plain strings

### DIFF
--- a/ejb/src/main/java/biz/karms/sinkit/ejb/MyCacheManagerProvider.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/MyCacheManagerProvider.java
@@ -36,6 +36,10 @@ public class MyCacheManagerProvider implements Serializable {
     private static final long MAX_ENTRIES_IOC = 10000000;
     private static final long MAX_ENTRIES_RULES = 5000;
 
+    public static final String BLACKLIST_CACHE = "BLACKLIST_CACHE";
+    public static final String RULES_CACHE = "RULES_CACHE";
+    public static final String CUSTOM_LISTS_CACHE = "CUSTOM_LISTS_CACHE";
+
     @Inject
     private Logger log;
 
@@ -103,12 +107,12 @@ public class MyCacheManagerProvider implements Serializable {
         //this.cache = this.manager.getCache("mycache");
         //this.cache.start();
 
-        manager.defineConfiguration("BLACKLIST_CACHE", loc);
-        manager.defineConfiguration("RULES_CACHE", loc);
-        manager.defineConfiguration("CUSTOM_LISTS_CACHE", loc);
-        manager.getCache("BLACKLIST_CACHE").start();
-        manager.getCache("RULES_CACHE").start();
-        manager.getCache("CUSTOM_LISTS_CACHE").start();
+        manager.defineConfiguration(BLACKLIST_CACHE, loc);
+        manager.defineConfiguration(RULES_CACHE, loc);
+        manager.defineConfiguration(CUSTOM_LISTS_CACHE, loc);
+        manager.getCache(BLACKLIST_CACHE).start();
+        manager.getCache(RULES_CACHE).start();
+        manager.getCache(CUSTOM_LISTS_CACHE).start();
 
         log.log(Level.INFO, "Caches defined.");
     }
@@ -123,12 +127,12 @@ public class MyCacheManagerProvider implements Serializable {
     public void destroy(@Observes @Destroyed(ApplicationScoped.class) Object init) {
         if (manager != null) {
             //TODO
-            manager.getCache("BLACKLIST_CACHE").stop();
-            manager.getCache("RULES_CACHE").stop();
-            manager.getCache("CUSTOM_LISTS_CACHE").stop();
-            manager.undefineConfiguration("BLACKLIST_CACHE");
-            manager.undefineConfiguration("RULES_CACHE");
-            manager.undefineConfiguration("CUSTOM_LISTS_CACHE");
+            manager.getCache(BLACKLIST_CACHE).stop();
+            manager.getCache(RULES_CACHE).stop();
+            manager.getCache(CUSTOM_LISTS_CACHE).stop();
+            manager.undefineConfiguration(BLACKLIST_CACHE);
+            manager.undefineConfiguration(RULES_CACHE);
+            manager.undefineConfiguration(CUSTOM_LISTS_CACHE);
             manager.stop();
             manager = null;
         }

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/CacheServiceEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/CacheServiceEJB.java
@@ -40,8 +40,8 @@ public class CacheServiceEJB implements CacheService {
 
     @PostConstruct
     public void setup() {
-        blacklistCache = m.getCache("BLACKLIST_CACHE");
-        ruleCache = m.getCache("RULES_CACHE");
+        blacklistCache = m.getCache(MyCacheManagerProvider.BLACKLIST_CACHE);
+        ruleCache = m.getCache(MyCacheManagerProvider.RULES_CACHE);
 
         if (blacklistCache == null || ruleCache == null) {
             throw new IllegalStateException("Both BLACKLIST_CACHE and RULES_CACHE must not be null.");

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/DNSApiEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/DNSApiEJB.java
@@ -86,9 +86,9 @@ public class DNSApiEJB implements DNSApi {
         if (m == null || coreService == null || webApi == null || archiveService == null) {
             throw new IllegalArgumentException("DefaultCacheManager, ArchiveService, WebApiEJB and CoreServiceEJB must be injected.");
         }
-        blacklistCache = m.getCache("BLACKLIST_CACHE");
-        ruleCache = m.getCache("RULES_CACHE");
-        customListsCache = m.getCache("CUSTOM_LISTS_CACHE");
+        blacklistCache = m.getCache(MyCacheManagerProvider.BLACKLIST_CACHE);
+        ruleCache = m.getCache(MyCacheManagerProvider.RULES_CACHE);
+        customListsCache = m.getCache(MyCacheManagerProvider.CUSTOM_LISTS_CACHE);
         if (blacklistCache == null || ruleCache == null || customListsCache == null) {
             throw new IllegalStateException("Both BLACKLIST_CACHE and RULES_CACHE and CUSTOM_LISTS_CACHE must not be null.");
         }

--- a/ejb/src/main/java/biz/karms/sinkit/ejb/impl/WebApiEJB.java
+++ b/ejb/src/main/java/biz/karms/sinkit/ejb/impl/WebApiEJB.java
@@ -53,9 +53,9 @@ public class WebApiEJB implements WebApi {
 
     @PostConstruct
     public void setup() {
-        blacklistCache = m.getCache("BLACKLIST_CACHE");
-        ruleCache = m.getCache("RULES_CACHE");
-        customListsCache = m.getCache("CUSTOM_LISTS_CACHE");
+        blacklistCache = m.getCache(MyCacheManagerProvider.BLACKLIST_CACHE);
+        ruleCache = m.getCache(MyCacheManagerProvider.RULES_CACHE);
+        customListsCache = m.getCache(MyCacheManagerProvider.CUSTOM_LISTS_CACHE);
         if (blacklistCache == null || ruleCache == null || customListsCache == null) {
             throw new IllegalStateException("Both BLACKLIST_CACHE and RULES_CACHE and CUSTOM_LISTS_CACHE must not be null.");
         }


### PR DESCRIPTION
just cosmetic modifications 